### PR TITLE
Preserve comments meant for other non-pylint tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ FAVICON = base64.decodestring(  # pylint: disable=deprecated-method
 
 Another issue is that messages that involve multiple files cannot be silenced. I'm aware of two such messages:
 
-*  cyclic-import
+* cyclic-import
 * duplicate-code
 
 You could just disable these messages. Personally I think that these are relevant messages. So instead I just modify `pylint` score calculation to something like:

--- a/tests/sample_2.py
+++ b/tests/sample_2.py
@@ -1,0 +1,25 @@
+"""This sample has some comments on lines to be reset!"""
+import os
+import sys
+# pylint: disable=unused-import
+import time
+# pylint: enable=unused-import
+
+import a_module_unknown_to_pylint  # pylint: disable=import-error # pants: no-infer-dep
+
+
+def func(name):
+    try:
+        # pylint: disable=exec-used
+        exec("1 + 1")
+        # pylint: enable=exec-used
+        val = eval("2 + 2")
+    except BaseException:
+        pass
+
+    foo: int = 'foo'  # pylint: disable=unused-variable,disallowed-name # noqa
+    bar: int = 'bar'  # noqa # pylint: disable=unused-variable,disallowed-name
+
+    10 / 0  # pylint: disable=pointless-statement # Dividing by zero is fun
+
+    global VAR

--- a/tests/sample_2_after_reset.py
+++ b/tests/sample_2_after_reset.py
@@ -1,0 +1,25 @@
+"""This sample has some comments on lines to be reset!"""
+import os
+import sys
+# pylint: disable=unused-import
+import time
+# pylint: enable=unused-import
+
+import a_module_unknown_to_pylint  # pants: no-infer-dep
+
+
+def func(name):
+    try:
+        # pylint: disable=exec-used
+        exec("1 + 1")
+        # pylint: enable=exec-used
+        val = eval("2 + 2")
+    except BaseException:
+        pass
+
+    foo: int = 'foo'  # noqa
+    bar: int = 'bar'  # noqa
+
+    10 / 0  # Dividing by zero is fun
+
+    global VAR

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -27,15 +27,22 @@ class Context:  # pylint: disable=too-few-public-methods
     def __init__(self, tmpdir: str) -> None:
         self.sample_filename = "tests/sample_1.py"
         self.sample_after_apply = "tests/sample_1_after_apply.py"
+        self.sample2_filename = "tests/sample_2.py"
+        self.sample2_after_reset = "tests/sample_2_after_reset.py"
 
-        # Check that input test files exsist.
+        # Check that input test files exist.
         assert os.path.isfile(self.sample_filename)
         assert os.path.isfile(self.sample_after_apply)
+        assert os.path.isfile(self.sample2_filename)
+        assert os.path.isfile(self.sample2_after_reset)
 
         # Copy test files to temp folder
         sample_basename = os.path.basename(self.sample_filename)
+        sample2_basename = os.path.basename(self.sample2_filename)
         self.temp_sample_filename = os.path.join(tmpdir, sample_basename)
         shutil.copy(self.sample_filename, self.temp_sample_filename)
+        self.temp_sample2_filename = os.path.join(tmpdir, sample2_basename)
+        shutil.copy(self.sample2_filename, self.temp_sample2_filename)
 
         sample_apply_basename = os.path.basename(self.sample_after_apply)
         self.temp_sample_after_apply = os.path.join(tmpdir, sample_apply_basename)
@@ -118,8 +125,19 @@ def test_reset(ctx: Context) -> None:
     assert filecmp.cmp(ctx.temp_sample_after_apply, ctx.sample_filename), \
         f"diff {ctx.temp_sample_filename} {ctx.sample_filename}"
 
-    # Test reseting a clean file.
+    # Test resetting a clean file.
     run_pylint_silent("reset", ctx.temp_sample_after_apply)
 
     assert filecmp.cmp(ctx.temp_sample_after_apply, ctx.sample_filename), \
         f"diff {ctx.temp_sample_filename} {ctx.sample_filename}"
+
+
+def test_reset_sample2(ctx: Context) -> None:
+    """Test 'pylint-silent reset' of the second sample file.
+
+    Remove all pylint comments and test that we preserve other comments
+    """
+    run_pylint_silent("reset", ctx.temp_sample2_filename)
+
+    assert filecmp.cmp(ctx.sample2_after_reset, ctx.temp_sample2_filename), \
+        f"diff {ctx.sample2_after_reset} {ctx.temp_sample2_filename}"

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =
     pylint
     {py37,py311}-pytest
 
-files = pylint_silent tests/test_sample_1.py
+files = pylint_silent tests/test_samples.py
 
 isolated_build = True
 


### PR DESCRIPTION
When running `pylint-silent reset`, the current behavior is to strip any
comments that can come *after* `# pylint: disable=`. This can cause
breakages for those other tools (including `mypy`, `pants`, `black`,
`isort`, others).

Of course, you *can* make sure that every `# pylint: disable=...` comment
is the last one on its line, but it's much nicer if we can preserve any
other comments that follow.

Change the behavior of `reset` so that it does not strip comments meant
for other tools.

This approach intentionally avoids using `re` (in keeping with the style
of existing code). It should impose a very, very mild hit to performance.